### PR TITLE
Add support for default PHP exception stack format

### DIFF
--- a/fluent-plugin-detect-exceptions.gemspec
+++ b/fluent-plugin-detect-exceptions.gemspec
@@ -11,7 +11,7 @@ eos
   gem.homepage      = \
     'https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions'
   gem.license       = 'Apache-2.0'
-  gem.version       = '0.0.1'
+  gem.version       = '0.0.2'
   gem.authors       = ['Thomas Schickinger']
   gem.email         = ['schickin@google.com']
   gem.required_ruby_version = Gem::Requirement.new('>= 2.0')

--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -66,8 +66,9 @@ module Fluent
     ].freeze
 
     PHP_RULES = [
-      rule(:start_state, /PHP (?:Notice|Parse error|Fatal error|Warning):/,
-           :php_stack_begin),
+      rule(:start_state, /
+        (?:PHP\ (?:Notice|Parse\ error|Fatal\ error|Warning):)|
+        (?:exception\ '[^']+'\ with\ message\ ')/x, :php_stack_begin),
       rule(:php_stack_begin, /^Stack trace:/, :php_stack_frames),
       rule(:php_stack_frames, /^#\d/, :php_stack_frames),
       rule(:php_stack_frames, /^\s+thrown in /, :start_state)

--- a/test/plugin/test_exception_detector.rb
+++ b/test/plugin/test_exception_detector.rb
@@ -252,6 +252,7 @@ END
     check_exception(PYTHON_EXC, true)
     check_exception(COMPLEX_JAVA_EXC, false)
     check_exception(NODE_JS_EXC, false)
+    check_exception(PHP_EXC, false)
     check_exception(PHP_ON_GAE_EXC, true)
     check_exception(CLIENT_JS_EXC, false)
     check_exception(GO_EXC, false)

--- a/test/plugin/test_exception_detector.rb
+++ b/test/plugin/test_exception_detector.rb
@@ -107,10 +107,10 @@ Exception: ('spam', 'eggs')
 END
 
   PHP_EXC = <<END.freeze
-exception 'Exception' with message 'Custom exception' in /Users/steren/work/test-php/test.php:5
+exception 'Exception' with message 'Custom exception' in /home/joe/work/test-php/test.php:5
 Stack trace:
-#0 /Users/steren/work/test-php/test.php(9): func1()
-#1 /Users/steren/work/test-php/test.php(13): func2()
+#0 /home/joe/work/test-php/test.php(9): func1()
+#1 /home/joe/work/test-php/test.php(13): func2()
 #2 {main}
 END
 

--- a/test/plugin/test_exception_detector.rb
+++ b/test/plugin/test_exception_detector.rb
@@ -107,6 +107,14 @@ Exception: ('spam', 'eggs')
 END
 
   PHP_EXC = <<END.freeze
+exception 'Exception' with message 'Custom exception' in /Users/steren/work/test-php/test.php:5
+Stack trace:
+#0 /Users/steren/work/test-php/test.php(9): func1()
+#1 /Users/steren/work/test-php/test.php(13): func2()
+#2 {main}
+END
+
+  PHP_ON_GAE_EXC = <<END.freeze
 PHP Fatal error:  Uncaught exception 'Exception' with message 'message' in /base/data/home/apps/s~crash-example-php/1.388306779641080894/errors.php:60
 Stack trace:
 #0 [internal function]: ErrorEntryGenerator::{closure}()
@@ -227,7 +235,8 @@ END
   end
 
   def test_php
-    check_exception(PHP_EXC, true)
+    check_exception(PHP_EXC, false)
+    check_exception(PHP_ON_GAE_EXC, true)
   end
 
   def test_go
@@ -243,7 +252,7 @@ END
     check_exception(PYTHON_EXC, true)
     check_exception(COMPLEX_JAVA_EXC, false)
     check_exception(NODE_JS_EXC, false)
-    check_exception(PHP_EXC, true)
+    check_exception(PHP_ON_GAE_EXC, true)
     check_exception(CLIENT_JS_EXC, false)
     check_exception(GO_EXC, false)
     check_exception(CSHARP_EXC, false)


### PR DESCRIPTION
This problem has been reported in issue #2  