### PR TITLE
Automatically add missing new lines when combining exception stacks and make remove_tag_prefix mandatory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,7 @@ Metrics/MethodLength:
 # Offense count: 3
 Metrics/PerceivedComplexity:
   Max: 50
+
+AllCops:
+  Exclude:
+  - '*.gemspec'

--- a/README.rdoc
+++ b/README.rdoc
@@ -2,8 +2,9 @@
 
 fluent-plugin-detect-exceptions is an
 {output plugin for fluentd}[http://docs.fluentd.org/articles/output-plugin-overview]
-which scans a log stream text messages or JSON records for multi-line exception
-stack traces: If a consecutive sequence of log messages forms an exception stack
+which scans a log stream text messages or JSON records containing single
+output lines for multi-line exception stack traces:
+If a consecutive sequence of single-line log messages forms an exception stack
 trace, the log messages are forwarded as a single, combined log message.
 Otherwise, the input log data is forwarded as is.
 
@@ -21,6 +22,9 @@ not reflected in the combined output. This plugin is intended to be used in
 cases where the content of log records that belong to a single exception stack
 are so similar (e.g. because they contain the timestamp of the log entry) that
 this loss of information is irrelevant.
+
+When combining exception lines, it is ensured that they enter with a line
+separator. If they don't, a line separator is added to the original log message.
 
 This is NOT an official Google product.
 
@@ -53,7 +57,9 @@ The plugin supports the following parameters:
                      a record. A prefix has to be a complete tag part.
                      Example: If remove_tag_prefix is set to 'foo', the input
                      tag foo.bar.baz is transformed to bar.baz and the input tag
-                     'foofoo.bar' is not modified. Default: empty string.
+                     'foofoo.bar' is not modified.
+                     Removing a tag prefix is needed to avoid infinite
+                     recursion in the fluentd config and is thus mandatory.
 
 [languages]  A list of language for which exception stack traces shall be
              detected. The values in the list can be separated by commas or

--- a/fluent-plugin-detect-exceptions.gemspec
+++ b/fluent-plugin-detect-exceptions.gemspec
@@ -11,12 +11,13 @@ eos
   gem.homepage      = \
     'https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions'
   gem.license       = 'Apache-2.0'
-  gem.version       = '0.0.5'
+  gem.version       = '0.0.6'
   gem.authors       = ['Thomas Schickinger']
   gem.email         = ['schickin@google.com']
   gem.required_ruby_version = Gem::Requirement.new('>= 2.0')
 
-  gem.files         = Dir['**/*'].keep_if { |file| File.file?(file) }
+  gem.files         = Dir['**/*'].keep_if{ |file| File.file?(file) &&
+                                                  !file.end_with?('gem') }
   gem.test_files    = gem.files.grep(/^(test)/)
   gem.require_paths = ['lib']
 

--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -223,6 +223,15 @@ module Fluent
       force_flush if @max_lines > 0 && @messages.length == @max_lines
     end
 
+    def combined_message
+      combined = ''
+      @messages.each do |m|
+        combined << $RS if !combined.empty? && !combined.end_with?("\n")
+        combined << m
+      end
+      combined
+    end
+
     def flush
       case @messages.length
       when 0
@@ -230,7 +239,6 @@ module Fluent
       when 1
         @emit.call(@first_timestamp, @first_record)
       else
-        combined_message = @messages.join
         if @message_field.nil?
           output_record = combined_message
         else
@@ -290,7 +298,7 @@ module Fluent
 
     def add(time_sec, record, message)
       if @messages.empty?
-        @first_record = record unless @message_field.nil?
+        @first_record = record
         @first_timestamp = time_sec
         @buffer_start_time = Time.now
       end

--- a/lib/fluent/plugin/out_detect_exceptions.rb
+++ b/lib/fluent/plugin/out_detect_exceptions.rb
@@ -25,7 +25,7 @@ module Fluent
     desc 'The field which contains the raw message text in the input JSON data.'
     config_param :message, :string, default: ''
     desc 'The prefix to be removed from the input tag when outputting a record.'
-    config_param :remove_tag_prefix, :string, default: ''
+    config_param :remove_tag_prefix, :string
     desc 'The interval of flushing the buffer for multiline format.'
     config_param :multiline_flush_interval, :time, default: nil
     desc 'Programming languages for which to detect exceptions. Default: all.'

--- a/test/plugin/test_exception_detector.rb
+++ b/test/plugin/test_exception_detector.rb
@@ -277,8 +277,8 @@ END
       m.each_line do |line|
         buffer.push(0, line)
       end
-      buffer.flush
     end
+    buffer.flush
   end
 
   Struct.new('TestBufferScenario', :desc, :languages, :input, :expected)
@@ -304,7 +304,15 @@ END
       buffer_scenario('all exceptions from non-configured languages',
                       [:ruby],
                       [JAVA_EXC, PYTHON_EXC, GO_EXC],
-                      JAVA_EXC.lines + PYTHON_EXC.lines + GO_EXC.lines)
+                      JAVA_EXC.lines + PYTHON_EXC.lines + GO_EXC.lines),
+      buffer_scenario('exception lines with missing line ending',
+                      [:all],
+                      (JAVA_EXC.lines +
+                       ARBITRARY_TEXT.lines +
+                       [PYTHON_EXC]).collect(&:chomp),
+                      [JAVA_EXC.chomp] +
+                      ARBITRARY_TEXT.lines.collect(&:chomp) +
+                      [PYTHON_EXC.chomp])
     ].each do |s|
       out = []
       buffer = Fluent::TraceAccumulator.new(nil,

--- a/test/plugin/test_out_detect_exceptions.rb
+++ b/test/plugin/test_out_detect_exceptions.rb
@@ -40,9 +40,9 @@ Traceback (most recent call last):
 Exception: ('spam', 'eggs')
 END
 
-  def create_driver(conf = CONFIG, tag = DEFAULT_TAG)
+  def create_driver(conf = '', tag = DEFAULT_TAG)
     d = Fluent::Test::OutputTestDriver.new(Fluent::DetectExceptionsOutput, tag)
-    d.configure(conf)
+    d.configure(CONFIG + conf)
     d
   end
 


### PR DESCRIPTION
This PR solves the following issues:

1. Text logs on GCE do not contain a trailing line end. Hence, we need to add it when combining exception stacks.
2. The fact that remove_tag_prefix is a pitfall for users because re-emitting a log entry with the same tag causes an infinite recursion in fluentd.
3. Flushing individual text log lines did not work because the first_record field was only populated for JSON logs.

The version number is bumped to 0.0.6