### PR TITLE
join_separator support for the output log line

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -95,6 +95,9 @@ The plugin supports the following parameters:
           This parameter is only applicable to structured (JSON) log streams.
           Default: ''.
 
+[join_separator] String used when joining multiple lines of the stack trace.
+                 Default: ''.
+
 Example configuration:
 
     <match **>

--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -194,10 +194,11 @@ module Fluent
     # The named parameters max_lines and max_bytes limit the maximum amount
     # of data to be buffered. The default value 0 indicates 'no limit'.
     def initialize(message_field, languages, max_lines: 0, max_bytes: 0,
-                   &emit_callback)
+                   join_separator: '', &emit_callback)
       @exception_detector = Fluent::ExceptionDetector.new(*languages)
       @max_lines = max_lines
       @max_bytes = max_bytes
+      @join_separator = join_separator
       @message_field = message_field
       @messages = []
       @buffer_start_time = Time.now
@@ -230,7 +231,7 @@ module Fluent
       when 1
         @emit.call(@first_timestamp, @first_record)
       else
-        combined_message = @messages.join
+        combined_message = @messages.join(@join_separator)
         if @message_field.nil?
           output_record = combined_message
         else

--- a/lib/fluent/plugin/out_detect_exceptions.rb
+++ b/lib/fluent/plugin/out_detect_exceptions.rb
@@ -36,6 +36,8 @@ module Fluent
     config_param :max_bytes, :integer, default: 0
     desc 'Separate log streams by this field in the input JSON data.'
     config_param :stream, :string, default: ''
+    desc 'String used when joining multiple lines of the stack trace'
+    config_param :join_separator, :string, default: ''
 
     Fluent::Plugin.register_output('detect_exceptions', self)
 
@@ -93,7 +95,8 @@ module Fluent
           @accumulators[log_id] =
             Fluent::TraceAccumulator.new(@message, @languages,
                                          max_lines: @max_lines,
-                                         max_bytes: @max_bytes) do |t, r|
+                                         max_bytes: @max_bytes,
+                                         join_separator: @join_separator) do |t, r|
               router.emit(out_tag, t, r)
             end
         end

--- a/test/plugin/test_exception_detector.rb
+++ b/test/plugin/test_exception_detector.rb
@@ -404,4 +404,17 @@ END
     # Check that the trace is flushed after the first part.
     assert_equal([JAVA_EXC_PART1] + JAVA_EXC_PART2.lines, out)
   end
+
+  def test_join_separator
+    # Custom join separator is used to join accumulated output
+    join_separator = ';'
+    out = []
+    buffer = Fluent::TraceAccumulator.new(nil,
+                                          [:all],
+                                          join_separator: join_separator) do |_, m|
+      out << m
+    end
+    feed_lines(buffer, JAVA_EXC)
+    assert_equal(JAVA_EXC.lines.length - 1, out[0].count(join_separator))
+  end
 end


### PR DESCRIPTION
The plugin is generating a flat log line which is really hard to read as full stack trace in a single line is not really human readable.

This PR adds support for `join_separator` that allows the user to customize the character that is used when concatenating detected stack trace lines (for example `join_separator "\n"` can be used).