### PR TITLE
Addition of prepend_tag_prefix parameter

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -55,6 +55,12 @@ The plugin supports the following parameters:
                      tag foo.bar.baz is transformed to bar.baz and the input tag
                      'foofoo.bar' is not modified. Default: empty string.
 
+[prepend_tag_prefix]  The prefix to add to the output tag when outputting
+                     a record.
+                     Example: If prepend_tag_prefix is set to 'foo', the input
+                     tag bar.baz is transformed to foo.bar.baz.
+                     Default: empty string.
+
 [languages]  A list of language for which exception stack traces shall be
              detected. The values in the list can be separated by commas or
              written as JSON list.

--- a/lib/fluent/plugin/out_detect_exceptions.rb
+++ b/lib/fluent/plugin/out_detect_exceptions.rb
@@ -26,6 +26,8 @@ module Fluent
     config_param :message, :string, default: ''
     desc 'The prefix to be removed from the input tag when outputting a record.'
     config_param :remove_tag_prefix, :string, default: ''
+    desc 'The prefix to be added to the output tag when outputting a record.'
+    config_param :prepend_tag_prefix, :string, default: ''
     desc 'The interval of flushing the buffer for multiline format.'
     config_param :multiline_flush_interval, :time, default: nil
     desc 'Programming languages for which to detect exceptions. Default: all.'
@@ -90,6 +92,7 @@ module Fluent
         log_id.push(record.fetch(@stream, '')) unless @stream.empty?
         unless @accumulators.key?(log_id)
           out_tag = tag.sub(/^#{Regexp.escape(@remove_tag_prefix)}\./, '')
+          out_tag = "#{Regexp.escape(@prepend_tag_prefix)}.#{out_tag}" unless @prepend_tag_prefix.empty?
           @accumulators[log_id] =
             Fluent::TraceAccumulator.new(@message, @languages,
                                          max_lines: @max_lines,


### PR DESCRIPTION
remove_tag_prefix removes a tag_part at the beginning of the message tag.
prepend_tag_prefix adds a tag_part at the beginning of the message tag.
The combination of both is like changing the tag prefix