### PR TITLE
Add Travis yml to enable pre-merge checks in GitHub.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+sudo: false
+rvm:
+  - 2.4
+  - 2.3.1
+  - 2.2
+  - 2.1
+script: "bundle exec rake"
+before_install:
+ - gem update bundler
+notifications:
+  email:
+    recipients:
+      - google-fluentd-notifications+travis@google.com
+    on_success: change
+    on_failure: change


### PR DESCRIPTION
This is an exact copy of the [Travis yml](https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/master/.travis.yml) in `fluent-plugin-google-cloud` assuming we are supporting the same versions of Ruby and sending notifications to the same email alias without further distinguishing them.