### PR TITLE
Remove fluentd v0.x version pin to allow v1.0.

### DIFF
--- a/fluent-plugin-detect-exceptions.gemspec
+++ b/fluent-plugin-detect-exceptions.gemspec
@@ -20,7 +20,7 @@ eos
   gem.test_files    = gem.files.grep(/^(test)/)
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'fluentd', '~> 0.10'
+  gem.add_runtime_dependency 'fluentd', '>= 0.10'
 
   gem.add_development_dependency 'rake', '~> 10.3'
   gem.add_development_dependency 'rubocop', '= 0.42.0'


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions/issues/21.