### PR TITLE
Add parsing rules, and a test case, for "Go panicing in a http handler"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 5
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 150
+  Max: 160
 
 # Offense count: 3
 Metrics/PerceivedComplexity:

--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -16,7 +16,7 @@ module Fluent
   Struct.new('Rule', :from_state, :pattern, :to_state)
 
   # Configuration of the state machine that detects exceptions.
-  module ExceptionDetectorConfig
+  module ExceptionDetectorConfig # rubocop:disable Metrics/ClassLength
     # Rule for a state transition: if pattern matches go to the given state.
     class RuleTarget
       attr_accessor :pattern, :to_state

--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -16,7 +16,7 @@ module Fluent
   Struct.new('Rule', :from_state, :pattern, :to_state)
 
   # Configuration of the state machine that detects exceptions.
-  module ExceptionDetectorConfig
+  module ExceptionDetectorConfig # rubocop:disable Metrics/ModuleLength
     # Rule for a state transition: if pattern matches go to the given state.
     class RuleTarget
       attr_accessor :pattern, :to_state

--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -16,7 +16,7 @@ module Fluent
   Struct.new('Rule', :from_state, :pattern, :to_state)
 
   # Configuration of the state machine that detects exceptions.
-  module ExceptionDetectorConfig # rubocop:disable Metrics/ClassLength
+  module ExceptionDetectorConfig
     # Rule for a state transition: if pattern matches go to the given state.
     class RuleTarget
       attr_accessor :pattern, :to_state

--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -76,6 +76,7 @@ module Fluent
 
     GO_RULES = [
       rule(:start_state, /\bpanic: /, :go_after_panic),
+      rule(:start_state, /http: panic /, :go_goroutine),
       rule(:go_after_panic, /^$/, :go_goroutine),
       rule(:go_after_panic, /^\[signal /, :go_after_signal),
       rule(:go_after_signal, /^$/, :go_goroutine),

--- a/test/plugin/test_exception_detector.rb
+++ b/test/plugin/test_exception_detector.rb
@@ -214,6 +214,26 @@ created by main.main
 	server.go:20 +0x91
 END
 
+  GO_HTTP = <<END.freeze
+2019/01/15 07:48:05 http: panic serving [::1]:54143: test panic
+goroutine 24 [running]:
+net/http.(*conn).serve.func1(0xc00007eaa0)
+	/usr/local/go/src/net/http/server.go:1746 +0xd0
+panic(0x12472a0, 0x12ece10)
+	/usr/local/go/src/runtime/panic.go:513 +0x1b9
+main.doPanic(0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+	/Users/ingvar/src/go/src/httppanic.go:8 +0x39
+net/http.HandlerFunc.ServeHTTP(0x12be2e8, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+	/usr/local/go/src/net/http/server.go:1964 +0x44
+net/http.(*ServeMux).ServeHTTP(0x14a17a0, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+	/usr/local/go/src/net/http/server.go:2361 +0x127
+net/http.serverHandler.ServeHTTP(0xc000085040, 0x12f0ea0, 0xc00010e1c0, 0xc000104400)
+	/usr/local/go/src/net/http/server.go:2741 +0xab
+net/http.(*conn).serve(0xc00007eaa0, 0x12f10a0, 0xc00008a780)
+	/usr/local/go/src/net/http/server.go:1847 +0x646
+created by net/http.(*Server).Serve
+	/usr/local/go/src/net/http/server.go:2851 +0x2f5
+END
   CSHARP_EXC = <<END.freeze
 System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2[System.String,System.Collections.Generic.Dictionary`2[System.Int32,System.Double]].get_Item (System.String key) [0x00000] in <filename unknown>:0
@@ -556,6 +576,7 @@ END
     check_exception(GO_EXC, false)
     check_exception(GO_ON_GAE_EXC, false)
     check_exception(GO_SIGNAL_EXC, false)
+    check_exception(GO_HTTP, false)
   end
 
   def test_ruby


### PR DESCRIPTION
When doing a test deployment of a fluentd container with this plugin baked in, I tried figuring out the correct configuration by spinning up a Go http server with a URL triggering a panic. It did take me quite a while to figure out why my panic stack traces were not being merged.

This PR adds the capability to merge panics triggered from within a http handler (and a test case).

The example HTTP handler I used to trigger the message is below:
```
package main

import (
	"net/http"
)

func doPanic(w http.ResponseWriter, r *http.Request) {
	panic("test panic")
}

func main() {
	http.HandleFunc("/", doPanic)
	http.ListenAndServe(":8080", nil)
}
```