### PR TITLE
Adding support for exception_tag_prefix #

### DIFF
--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -247,6 +247,7 @@ module Fluent
     def initialize(message_field, languages, max_lines: 0, max_bytes: 0,
                    &emit_callback)
       @exception_detector = Fluent::ExceptionDetector.new(*languages)
+      @has_exception = false
       @max_lines = max_lines
       @max_bytes = max_bytes
       @message_field = message_field
@@ -279,7 +280,7 @@ module Fluent
       when 0
         return
       when 1
-        @emit.call(@first_timestamp, @first_record)
+        @emit.call(@first_timestamp, @first_record, @has_exception)
       else
         combined_message = @messages.join
         if @message_field.nil?
@@ -288,7 +289,7 @@ module Fluent
           output_record = @first_record
           output_record[@message_field] = combined_message
         end
-        @emit.call(@first_timestamp, output_record)
+        @emit.call(@first_timestamp, output_record, @has_exception)
       end
       @messages = []
       @first_record = nil
@@ -319,22 +320,26 @@ module Fluent
       trigger_emit = detection_status == :no_trace ||
                      detection_status == :end_trace
       if @messages.empty? && trigger_emit
-        @emit.call(time_sec, record)
+        @emit.call(time_sec, record, detection_status == :end_trace)
         return
       end
 
       case detection_status
       when :inside_trace
+        @has_exception = true
         add(time_sec, record, message)
       when :end_trace
+        @has_exception = true
         add(time_sec, record, message)
         flush
       when :no_trace
         flush
+        @has_exception = false
         add(time_sec, record, message)
         flush
       when :start_trace
         flush
+        @has_exception = true
         add(time_sec, record, message)
       end
     end

--- a/test/plugin/test_out_detect_exceptions.rb
+++ b/test/plugin/test_out_detect_exceptions.rb
@@ -243,6 +243,30 @@ END
     assert_equal(['prefix.plus.rest.of.the.tag'], tags)
   end
 
+  def test_exception_tag_prefix
+    original_tag = 'log'
+    with_exception_tag = "exception.#{original_tag}"
+    cfg = 'exception_tag_prefix exception'
+    d = create_driver(cfg, original_tag)
+    expected = [original_tag, with_exception_tag, original_tag]
+    run_driver(d, ARBITRARY_TEXT, JAVA_EXC, ARBITRARY_TEXT)
+    assert_equal(d.emits.collect { |e| e[0] }, expected)
+  end
+
+  def test_exception_tag_prefix_remove_old
+    without_prefix = 'log'
+    original = "old.#{without_prefix}"
+    with_exception_tag = "exception.#{without_prefix}"
+    cfg = %(
+       exception_tag_prefix exception
+       remove_tag_prefix old
+    )
+    d = create_driver(cfg, original)
+    expected = [without_prefix, with_exception_tag, without_prefix]
+    run_driver(d, ARBITRARY_TEXT, JAVA_EXC, ARBITRARY_TEXT)
+    assert_equal(d.emits.collect { |e| e[0] }, expected)
+  end
+
   def test_flush_after_max_lines
     cfg = 'max_lines 2'
     d = create_driver(cfg)


### PR DESCRIPTION
The tag will be added to messages with the detected exceptions.
This is useful if you want to handle them specifically
#54 