### PR TITLE
add detection of PSQLExceptions with Position:

### DIFF
--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -58,6 +58,7 @@ module Fluent
       rule(:java_after_exception, /^[\t ]*nested exception is:[\t ]*/,
            :java_start_exception),
       rule(:java_after_exception, /^[\r\n]*$/, :java_after_exception),
+      rule(:java_after_exception, /^[\t ]+Position: /, :java_after_exception),
       rule([:java_after_exception, :java], /^[\t ]+(?:eval )?at /, :java),
       rule([:java_after_exception, :java], /^[\t ]*(?:Caused by|Suppressed):/,
            :java_after_exception),


### PR DESCRIPTION
Detect exceptions like:

```
Exception org.postgresql.util.PSQLException: ERROR: relation "received_events" does not exist
  Position: 15
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2422) ~[postgresql-42.2.1.jar!/:42.2.1]
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2167) ~[postgresql-42.2.1.jar!/:42.2.1]
        ...
```