### PR TITLE
[Enhancement] simplify python rules

### DIFF
--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -79,8 +79,7 @@ module Fluent
 
     PYTHON_RULES = [
       rule(:start_state, /^Traceback \(most recent call last\):$/, :python),
-      rule(:python, /^[\t ]+File /, :python_code),
-      rule(:python_code, /[^\t ]/, :python),
+      rule(:python, /^[\t ]+[\S]+.*/, :python),
       rule(:python, /^(?:[^\s.():]+\.)*[^\s.():]+:/, :start_state)
     ].freeze
 


### PR DESCRIPTION
## What

Simplify python rules to only have 2 states and a single regex for matching lines between the start (`Traceback ...`) and End (`<Error>...`) of a Traceback.
The new regex matches any line that starts with one or more tabs/spaces, followed by at least one non-whitespace symbol, followed by whatever else.

## Why

This is the second proposed option here: https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions/issues/62#issuecomment-543047036

Fix #62 

---

FYI @jkschulz & @igorpeshansky 