### PR TITLE
Feature/adding the parameter add line break

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -66,6 +66,13 @@ The plugin supports the following parameters:
                             forwarded. If not set, incomplete exceptions stacks
                             are not flushed.
 
+[add_line_break]  Force the addition of the line break '\n' operator between
+                  each line. This is usefull if you want to send the exception
+                  as one message but format it as a regular exception.
+                  If this is set to true, a line break will be added.
+                  added between each lines of the exception.
+                  Default: false.
+
 [max_lines]  Maximum number of lines in a detected exception stack trace.
              If this maximum number is exceeded, the exception stack trace
              that has been detected so far will be output as a single

--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -42,8 +42,7 @@ module Fluent
     end
 
     def self.rule(from_state_or_states, pattern, to_state)
-      from_state_or_states = [from_state_or_states] unless
-        from_state_or_states.is_a?(Array)
+      from_state_or_states = [from_state_or_states] unless from_state_or_states.is_a?(Array)
       Struct::Rule.new(from_state_or_states, pattern, to_state)
     end
 
@@ -52,120 +51,120 @@ module Fluent
     end
 
     JAVA_RULES = [
-      rule([:start_state, :java_start_exception],
-           /(?:Exception|Error|Throwable|V8 errors stack trace)[:\r\n]/,
-           :java_after_exception),
-      rule(:java_after_exception, /^[\t ]*nested exception is:[\t ]*/,
-           :java_start_exception),
-      rule(:java_after_exception, /^[\r\n]*$/, :java_after_exception),
-      rule([:java_after_exception, :java], /^[\t ]+(?:eval )?at /, :java),
+        rule([:start_state, :java_start_exception],
+             /(?:Exception|Error|Throwable|V8 errors stack trace)[:\r\n]/,
+             :java_after_exception),
+        rule(:java_after_exception, /^[\t ]*nested exception is:[\t ]*/,
+             :java_start_exception),
+        rule(:java_after_exception, /^[\r\n]*$/, :java_after_exception),
+        rule([:java_after_exception, :java], /^[\t ]+(?:eval )?at /, :java),
 
-      rule([:java_after_exception, :java],
-           # C# nested exception.
-           /^[\t ]+--- End of inner exception stack trace ---$/,
-           :java),
+        rule([:java_after_exception, :java],
+             # C# nested exception.
+             /^[\t ]+--- End of inner exception stack trace ---$/,
+             :java),
 
-      rule([:java_after_exception, :java],
-           # C# exception from async code.
-           /^--- End of stack trace from previous (?x:
+        rule([:java_after_exception, :java],
+             # C# exception from async code.
+             /^--- End of stack trace from previous (?x:
            )location where exception was thrown ---$/,
-           :java),
+             :java),
 
-      rule([:java_after_exception, :java], /^[\t ]*(?:Caused by|Suppressed):/,
-           :java_after_exception),
-      rule([:java_after_exception, :java],
-           /^[\t ]*... \d+ (?:more|common frames omitted)/, :java)
+        rule([:java_after_exception, :java], /^[\t ]*(?:Caused by|Suppressed):/,
+             :java_after_exception),
+        rule([:java_after_exception, :java],
+             /^[\t ]*... \d+ (?:more|common frames omitted)/, :java)
     ].freeze
 
     PYTHON_RULES = [
-      rule(:start_state, /^Traceback \(most recent call last\):$/, :python),
-      rule(:python, /^[\t ]+File /, :python_code),
-      rule(:python_code, /[^\t ]/, :python),
-      rule(:python, /^(?:[^\s.():]+\.)*[^\s.():]+:/, :start_state)
+        rule(:start_state, /^Traceback \(most recent call last\):$/, :python),
+        rule(:python, /^[\t ]+File /, :python_code),
+        rule(:python_code, /[^\t ]/, :python),
+        rule(:python, /^(?:[^\s.():]+\.)*[^\s.():]+:/, :start_state)
     ].freeze
 
     PHP_RULES = [
-      rule(:start_state, /
+        rule(:start_state, /
         (?:PHP\ (?:Notice|Parse\ error|Fatal\ error|Warning):)|
         (?:exception\ '[^']+'\ with\ message\ ')/x, :php_stack_begin),
-      rule(:php_stack_begin, /^Stack trace:/, :php_stack_frames),
-      rule(:php_stack_frames, /^#\d/, :php_stack_frames),
-      rule(:php_stack_frames, /^\s+thrown in /, :start_state)
+        rule(:php_stack_begin, /^Stack trace:/, :php_stack_frames),
+        rule(:php_stack_frames, /^#\d/, :php_stack_frames),
+        rule(:php_stack_frames, /^\s+thrown in /, :start_state)
     ].freeze
 
     GO_RULES = [
-      rule(:start_state, /\bpanic: /, :go_after_panic),
-      rule(:start_state, /http: panic serving/, :go_goroutine),
-      rule(:go_after_panic, /^$/, :go_goroutine),
-      rule([:go_after_panic, :go_after_signal, :go_frame_1],
-           /^$/, :go_goroutine),
-      rule(:go_after_panic, /^\[signal /, :go_after_signal),
-      rule(:go_goroutine, /^goroutine \d+ \[[^\]]+\]:$/, :go_frame_1),
-      rule(:go_frame_1, /^(?:[^\s.:]+\.)*[^\s.():]+\(|^created by /,
-           :go_frame_2),
-      rule(:go_frame_2, /^\s/, :go_frame_1)
+        rule(:start_state, /\bpanic: /, :go_after_panic),
+        rule(:start_state, /http: panic serving/, :go_goroutine),
+        rule(:go_after_panic, /^$/, :go_goroutine),
+        rule([:go_after_panic, :go_after_signal, :go_frame_1],
+             /^$/, :go_goroutine),
+        rule(:go_after_panic, /^\[signal /, :go_after_signal),
+        rule(:go_goroutine, /^goroutine \d+ \[[^\]]+\]:$/, :go_frame_1),
+        rule(:go_frame_1, /^(?:[^\s.:]+\.)*[^\s.():]+\(|^created by /,
+             :go_frame_2),
+        rule(:go_frame_2, /^\s/, :go_frame_1)
     ].freeze
 
     RUBY_RULES = [
-      rule(:start_state, /Error \(.*\):$/, :ruby_before_rails_trace),
-      rule(:ruby_before_rails_trace, /^  $/, :ruby),
-      rule(:ruby_before_rails_trace, /^[\t ]+.*?\.rb:\d+:in `/, :ruby),
-      rule(:ruby, /^[\t ]+.*?\.rb:\d+:in `/, :ruby)
+        rule(:start_state, /Error \(.*\):$/, :ruby_before_rails_trace),
+        rule(:ruby_before_rails_trace, /^  $/, :ruby),
+        rule(:ruby_before_rails_trace, /^[\t ]+.*?\.rb:\d+:in `/, :ruby),
+        rule(:ruby, /^[\t ]+.*?\.rb:\d+:in `/, :ruby)
     ].freeze
 
     DART_RULES = [
-      rule(:start_state, /^Unhandled exception:$/, :dart_exc),
-      rule(:dart_exc, /^Instance of/, :dart_stack),
-      rule(:dart_exc, /^Exception/, :dart_stack),
-      rule(:dart_exc, /^Bad state/, :dart_stack),
-      rule(:dart_exc, /^IntegerDivisionByZeroException/, :dart_stack),
-      rule(:dart_exc, /^Invalid argument/, :dart_stack),
-      rule(:dart_exc, /^RangeError/, :dart_stack),
-      rule(:dart_exc, /^Assertion failed/, :dart_stack),
-      rule(:dart_exc, /^Cannot instantiate/, :dart_stack),
-      rule(:dart_exc, /^Reading static variable/, :dart_stack),
-      rule(:dart_exc, /^UnimplementedError/, :dart_stack),
-      rule(:dart_exc, /^Unsupported operation/, :dart_stack),
-      rule(:dart_exc, /^Concurrent modification/, :dart_stack),
-      rule(:dart_exc, /^Out of Memory/, :dart_stack),
-      rule(:dart_exc, /^Stack Overflow/, :dart_stack),
-      rule(:dart_exc, /^'.+?':.+?$/, :dart_type_err_1),
-      rule(:dart_type_err_1, /^#\d+\s+.+?\(.+?\)$/, :dart_stack),
-      rule(:dart_type_err_1, /^.+?$/, :dart_type_err_2),
-      rule(:dart_type_err_2, /^.*?\^.*?$/, :dart_type_err_3),
-      rule(:dart_type_err_3, /^$/, :dart_type_err_4),
-      rule(:dart_type_err_4, /^$/, :dart_stack),
-      rule(:dart_exc, /^FormatException/, :dart_format_err_1),
-      rule(:dart_format_err_1, /^#\d+\s+.+?\(.+?\)$/, :dart_stack),
-      rule(:dart_format_err_1, /^./, :dart_format_err_2),
-      rule(:dart_format_err_2, /^.*?\^/, :dart_format_err_3),
-      rule(:dart_format_err_3, /^$/, :dart_stack),
-      rule(:dart_exc, /^NoSuchMethodError:/, :dart_method_err_1),
-      rule(:dart_method_err_1, /^Receiver:/, :dart_method_err_2),
-      rule(:dart_method_err_2, /^Tried calling:/, :dart_method_err_3),
-      rule(:dart_method_err_3, /^Found:/, :dart_stack),
-      rule(:dart_method_err_3, /^#\d+\s+.+?\(.+?\)$/, :dart_stack),
-      rule(:dart_stack, /^#\d+\s+.+?\(.+?\)$/, :dart_stack),
-      rule(:dart_stack, /^<asynchronous suspension>$/, :dart_stack)
+        rule(:start_state, /^Unhandled exception:$/, :dart_exc),
+        rule(:dart_exc, /^Instance of/, :dart_stack),
+        rule(:dart_exc, /^Exception/, :dart_stack),
+        rule(:dart_exc, /^Bad state/, :dart_stack),
+        rule(:dart_exc, /^IntegerDivisionByZeroException/, :dart_stack),
+        rule(:dart_exc, /^Invalid argument/, :dart_stack),
+        rule(:dart_exc, /^RangeError/, :dart_stack),
+        rule(:dart_exc, /^Assertion failed/, :dart_stack),
+        rule(:dart_exc, /^Cannot instantiate/, :dart_stack),
+        rule(:dart_exc, /^Reading static variable/, :dart_stack),
+        rule(:dart_exc, /^UnimplementedError/, :dart_stack),
+        rule(:dart_exc, /^Unsupported operation/, :dart_stack),
+        rule(:dart_exc, /^Concurrent modification/, :dart_stack),
+        rule(:dart_exc, /^Out of Memory/, :dart_stack),
+        rule(:dart_exc, /^Stack Overflow/, :dart_stack),
+        rule(:dart_exc, /^'.+?':.+?$/, :dart_type_err_1),
+        rule(:dart_type_err_1, /^#\d+\s+.+?\(.+?\)$/, :dart_stack),
+        rule(:dart_type_err_1, /^.+?$/, :dart_type_err_2),
+        rule(:dart_type_err_2, /^.*?\^.*?$/, :dart_type_err_3),
+        rule(:dart_type_err_3, /^$/, :dart_type_err_4),
+        rule(:dart_type_err_4, /^$/, :dart_stack),
+        rule(:dart_exc, /^FormatException/, :dart_format_err_1),
+        rule(:dart_format_err_1, /^#\d+\s+.+?\(.+?\)$/, :dart_stack),
+        rule(:dart_format_err_1, /^./, :dart_format_err_2),
+        rule(:dart_format_err_2, /^.*?\^/, :dart_format_err_3),
+        rule(:dart_format_err_3, /^$/, :dart_stack),
+        rule(:dart_exc, /^NoSuchMethodError:/, :dart_method_err_1),
+        rule(:dart_method_err_1, /^Receiver:/, :dart_method_err_2),
+        rule(:dart_method_err_2, /^Tried calling:/, :dart_method_err_3),
+        rule(:dart_method_err_3, /^Found:/, :dart_stack),
+        rule(:dart_method_err_3, /^#\d+\s+.+?\(.+?\)$/, :dart_stack),
+        rule(:dart_stack, /^#\d+\s+.+?\(.+?\)$/, :dart_stack),
+        rule(:dart_stack, /^<asynchronous suspension>$/, :dart_stack)
     ].freeze
 
     ALL_RULES = (
-      JAVA_RULES + PYTHON_RULES + PHP_RULES + GO_RULES + RUBY_RULES + DART_RULES
+    JAVA_RULES + PYTHON_RULES + PHP_RULES + GO_RULES + RUBY_RULES + DART_RULES
     ).freeze
 
     RULES_BY_LANG = {
-      java: JAVA_RULES,
-      javascript: JAVA_RULES,
-      js: JAVA_RULES,
-      csharp: JAVA_RULES,
-      py: PYTHON_RULES,
-      python: PYTHON_RULES,
-      php: PHP_RULES,
-      go: GO_RULES,
-      rb: RUBY_RULES,
-      ruby: RUBY_RULES,
-      dart: DART_RULES,
-      all: ALL_RULES
+        java: JAVA_RULES,
+        javascript: JAVA_RULES,
+        js: JAVA_RULES,
+        csharp: JAVA_RULES,
+        py: PYTHON_RULES,
+        python: PYTHON_RULES,
+        php: PHP_RULES,
+        go: GO_RULES,
+        rb: RUBY_RULES,
+        ruby: RUBY_RULES,
+        dart: DART_RULES,
+        all: ALL_RULES
     }.freeze
 
     DEFAULT_FIELDS = %w(message log).freeze
@@ -182,9 +181,9 @@ module Fluent
 
       languages.each do |lang|
         rule_config =
-          ExceptionDetectorConfig::RULES_BY_LANG.fetch(lang.downcase) do |_k|
-            raise ArgumentError, "Unknown language: #{lang}"
-          end
+            ExceptionDetectorConfig::RULES_BY_LANG.fetch(lang.downcase) do |_k|
+              raise ArgumentError, "Unknown language: #{lang}"
+            end
 
         rule_config.each do |r|
           target = ExceptionDetectorConfig::RuleTarget.new(r[:pattern],
@@ -256,11 +255,13 @@ module Fluent
     # message_field may contain the empty string. In this case, the
     # TraceAccumulator 'learns' the field name from the first record by checking
     # for some pre-defined common field names of text logs.
+    # The named parameter add_line_break forces linebreak between raw messages.
     # The named parameters max_lines and max_bytes limit the maximum amount
     # of data to be buffered. The default value 0 indicates 'no limit'.
-    def initialize(message_field, languages, max_lines: 0, max_bytes: 0,
+    def initialize(message_field, languages, add_line_break: false, max_lines: 0, max_bytes: 0,
                    &emit_callback)
       @exception_detector = Fluent::ExceptionDetector.new(*languages)
+      @add_line_break = add_line_break
       @max_lines = max_lines
       @max_bytes = max_bytes
       @message_field = message_field
@@ -279,7 +280,7 @@ module Fluent
         detection_status = :no_trace
       else
         force_flush if @max_bytes > 0 &&
-                       @buffer_size + message.length > @max_bytes
+            @buffer_size + message.length > @max_bytes
         detection_status = @exception_detector.update(message)
       end
 
@@ -331,7 +332,7 @@ module Fluent
 
     def update_buffer(detection_status, time_sec, record, message)
       trigger_emit = detection_status == :no_trace ||
-                     detection_status == :end_trace
+          detection_status == :end_trace
       if @messages.empty? && trigger_emit
         @emit.call(time_sec, record)
         return
@@ -360,8 +361,14 @@ module Fluent
         @buffer_start_time = Time.now
       end
       unless message.nil?
-        @messages << message
-        @buffer_size += message.length
+        message_with_line_break =
+            if @add_line_break && !@messages.empty?
+              "\n" + message
+            else
+              message
+            end
+        @messages << message_with_line_break
+        @buffer_size += message_with_line_break.length
       end
     end
   end

--- a/lib/fluent/plugin/out_detect_exceptions.rb
+++ b/lib/fluent/plugin/out_detect_exceptions.rb
@@ -30,6 +30,8 @@ module Fluent
     config_param :multiline_flush_interval, :time, default: nil
     desc 'Programming languages for which to detect exceptions. Default: all.'
     config_param :languages, :array, value_type: :string, default: []
+    desc 'Force the application to add a line break between the raw message text. Default: false.'
+    config_param :add_line_break, :bool, default: false
     desc 'Maximum number of lines to flush (0 means no limit). Default: 1000.'
     config_param :max_lines, :integer, default: 1000
     desc 'Maximum number of bytes to flush (0 means no limit). Default: 0.'
@@ -92,6 +94,7 @@ module Fluent
           out_tag = tag.sub(/^#{Regexp.escape(@remove_tag_prefix)}\./, '')
           @accumulators[log_id] =
             Fluent::TraceAccumulator.new(@message, @languages,
+                                         add_line_break: @add_line_break,
                                          max_lines: @max_lines,
                                          max_bytes: @max_bytes) do |t, r|
               router.emit(out_tag, t, r)

--- a/test/plugin/test_out_detect_exceptions.rb
+++ b/test/plugin/test_out_detect_exceptions.rb
@@ -244,7 +244,7 @@ END
   end
 
   def test_add_line_break_false
-    cfg = 'add_line_break true'
+    cfg = 'add_line_break false'
     d = create_driver(cfg)
     t = Time.now.to_i
     d.run do

--- a/test/plugin/test_out_detect_exceptions.rb
+++ b/test/plugin/test_out_detect_exceptions.rb
@@ -243,6 +243,34 @@ END
     assert_equal(['prefix.plus.rest.of.the.tag'], tags)
   end
 
+  def test_add_line_break_false
+    cfg = 'add_line_break true'
+    d = create_driver(cfg)
+    t = Time.now.to_i
+    d.run do
+      feed_lines(d, t, JAVA_EXC)
+    end
+    expected = JAVA_EXC
+    assert_equal(make_logs(t, *expected), d.events)
+  end
+
+  def test_add_line_break_true
+    cfg = 'add_line_break true'
+    d = create_driver(cfg)
+    t = Time.now.to_i
+    d.run do
+      feed_lines(d, t, JAVA_EXC)
+    end
+    # Expected: the first two lines of the exception are buffered and combined.
+    # Then the max_lines setting kicks in and the rest of the Python exception
+    # is logged line-by-line (since it's not an exception stack in itself).
+    # For the following Java stack trace, the two lines of the first exception
+    # are buffered and combined. So are the first two lines of the second
+    # exception. Then the rest is logged line-by-line.
+    expected = JAVA_EXC.lines.join("\n")
+    assert_equal(make_logs(t, *expected), d.events)
+  end
+
   def test_flush_after_max_lines
     cfg = 'max_lines 2'
     d = create_driver(cfg)


### PR DESCRIPTION
The goal of this PR is to add a way to enable automated line break between each line of the stack trace.

The docker's fluentd logging forwarder, is removing the line break between each exception line. 
Without this feature, you get the entire stacktrace on one line.

To use this feature, you must use the optional boolean parameter "add_line_break". By default, it will be set to false to make sure the integration of this feature is transparent for the current users.

Without the add_line_break feature:
![image](https://user-images.githubusercontent.com/4604501/69267134-8b68ed00-0b9a-11ea-990a-80a22363ccdd.png)

With the add_line_break freature:
![image](https://user-images.githubusercontent.com/4604501/69267248-c4a15d00-0b9a-11ea-95da-b09c61255f11.png)


`
\<source>
  @type forward
  port 24224
  bind 0.0.0.0
  @label @RAW
\</source>

\<label @RAW>
        \<match **>
          @type detect_exceptions
          languages java
          message log
          multiline_flush_interval 1.0
          add_line_break true
          @label @COOKED
        \</match>
\</label>

\<label @COOKED>
        \<match **>
          @type splunk_hec
          ... 
        \</match>
\</label>
`