### PR TITLE
adding new optional parameter `force_line_breaks`.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -66,6 +66,12 @@ The plugin supports the following parameters:
                             forwarded. If not set, incomplete exceptions stacks
                             are not flushed.
 
+[force_live_breaks]  Force line breaks between each lines when comibining exception stacks.
+                     This is useful if your exception is formatted
+                     as a single line. i.e., logs retrieved from the docker's
+                     logging driver don't have any line break.
+                     Default: false.
+
 [max_lines]  Maximum number of lines in a detected exception stack trace.
              If this maximum number is exceeded, the exception stack trace
              that has been detected so far will be output as a single

--- a/README.rdoc
+++ b/README.rdoc
@@ -66,7 +66,7 @@ The plugin supports the following parameters:
                             forwarded. If not set, incomplete exceptions stacks
                             are not flushed.
 
-[force_live_breaks]  Force line breaks between each lines when comibining exception stacks.
+[force_line_breaks]  Force line breaks between each lines when comibining exception stacks.
                      This is useful if your exception is formatted
                      as a single line. i.e., logs retrieved from the docker's
                      logging driver don't have any line break.

--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -256,20 +256,22 @@ module Fluent
     # message_field may contain the empty string. In this case, the
     # TraceAccumulator 'learns' the field name from the first record by checking
     # for some pre-defined common field names of text logs.
-    # The named parameters max_lines and max_bytes limit the maximum amount
+    # The option parameter can be used to pass the following parameters:
+    # force_line_breaks adds line breaks when combining exception stacks
+    # max_lines and max_bytes limit the maximum amount
     # of data to be buffered. The default value 0 indicates 'no limit'.
-    def initialize(message_field, languages, max_lines: 0, max_bytes: 0,
-                   &emit_callback)
+    def initialize(message_field, languages, **options, &emit_callback)
       @exception_detector = Fluent::ExceptionDetector.new(*languages)
-      @max_lines = max_lines
-      @max_bytes = max_bytes
       @message_field = message_field
+      @force_line_breaks = options[:force_line_breaks] || false
+      @max_lines = options[:max_lines]           || 0
+      @max_bytes = options[:max_bytes]           || 0
+      @emit = emit_callback
       @messages = []
       @buffer_start_time = Time.now
       @buffer_size = 0
       @first_record = nil
       @first_timestamp = nil
-      @emit = emit_callback
     end
 
     def push(time_sec, record)
@@ -360,8 +362,14 @@ module Fluent
         @buffer_start_time = Time.now
       end
       unless message.nil?
-        @messages << message
-        @buffer_size += message.length
+        message_with_line_break =
+          if @force_line_breaks && !@messages.empty? && !message.include?("\n")
+            "\n" + message
+          else
+            message
+          end
+        @messages << message_with_line_break
+        @buffer_size += message_with_line_break.length
       end
     end
   end

--- a/lib/fluent/plugin/out_detect_exceptions.rb
+++ b/lib/fluent/plugin/out_detect_exceptions.rb
@@ -30,6 +30,8 @@ module Fluent
     config_param :multiline_flush_interval, :time, default: nil
     desc 'Programming languages for which to detect exceptions. Default: all.'
     config_param :languages, :array, value_type: :string, default: []
+    desc 'Force live breaks when combining exception stacks. Default: false.'
+    config_param :force_line_breaks, :bool, default: false
     desc 'Maximum number of lines to flush (0 means no limit). Default: 1000.'
     config_param :max_lines, :integer, default: 1000
     desc 'Maximum number of bytes to flush (0 means no limit). Default: 0.'
@@ -91,9 +93,13 @@ module Fluent
         unless @accumulators.key?(log_id)
           out_tag = tag.sub(/^#{Regexp.escape(@remove_tag_prefix)}\./, '')
           @accumulators[log_id] =
-            Fluent::TraceAccumulator.new(@message, @languages,
-                                         max_lines: @max_lines,
-                                         max_bytes: @max_bytes) do |t, r|
+            Fluent::TraceAccumulator.new(
+              @message,
+              @languages,
+              force_line_breaks: @force_line_breaks,
+              max_lines: @max_lines,
+              max_bytes: @max_bytes
+            ) do |t, r|
               router.emit(out_tag, t, r)
             end
         end

--- a/test/plugin/test_out_detect_exceptions.rb
+++ b/test/plugin/test_out_detect_exceptions.rb
@@ -271,7 +271,9 @@ multiline_flush_interval 1)
   end
 
   def test_force_line_breaks_false
-    cfg = 'force_line_breaks false'
+    cfg = %(
+#{CONFIG}
+force_line_breaks true)
     d = create_driver(cfg)
     t = Time.now.to_i
     d.run do
@@ -282,7 +284,9 @@ multiline_flush_interval 1)
   end
 
   def test_force_line_breaks_true
-    cfg = 'force_line_breaks true'
+    cfg = %(
+#{CONFIG}
+force_line_breaks true)
     d = create_driver(cfg)
     t = Time.now.to_i
     d.run do


### PR DESCRIPTION
The goal of this PR is to add a way to enable automated line break between each line of the stack trace.

The docker's fluentd logging forwarder, is removing the line break between each exception line. 
Without this feature, you get the entire stacktrace on one line.

To use this feature, you must use the optional boolean parameter `force_line_breaks`. By default, it will be set to false to make sure the integration of this feature is transparent for the current users.

Without the `force_line_breaks` feature:
![image](https://user-images.githubusercontent.com/4604501/69267134-8b68ed00-0b9a-11ea-990a-80a22363ccdd.png)

With the `force_line_breaks` freature:
![image](https://user-images.githubusercontent.com/4604501/69267248-c4a15d00-0b9a-11ea-95da-b09c61255f11.png)


```
\<source>
  @type forward
  port 24224
  bind 0.0.0.0
  @label @RAW
\</source>

\<label @RAW>
        \<match **>
          @type detect_exceptions
          languages java
          message log
          multiline_flush_interval 1.0
          force_line_breaks true
          @label @COOKED
        \</match>
\</label>

\<label @COOKED>
        \<match **>
          @type splunk_hec
          ... 
        \</match>
\</label>
```