### PR TITLE
Go Exceptions completion

### DIFF
--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -96,6 +96,7 @@ module Fluent
     GO_RULES = [
       rule(:start_state, /\bpanic: /, :go_after_panic),
       rule(:start_state, /http: panic serving/, :go_goroutine),
+      rule(:start_state, /^goroutine \d+ \[[^\]]+\]:$/, :go_frame_1),
       rule(:go_after_panic, /^$/, :go_goroutine),
       rule([:go_after_panic, :go_after_signal, :go_frame_1],
            /^$/, :go_goroutine),


### PR DESCRIPTION
The Kubernetes API server may throw exceptions that would not be caught by that plugin.

A concrete sample would be to deploy FUSE on OpenShift, with NetworkPolicies.
If said NetworkPolicies prevent the k8s API server to communicate with some Jolokia service, then we would find a trace in the API server logs.
That traces starts with a `goroutine <int> ...`, with no prior mention of a "panic" or "http: panic".