### PR TITLE
Add functionality to modify record tag for matched exceptions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -95,6 +95,13 @@ The plugin supports the following parameters:
           This parameter is only applicable to structured (JSON) log streams.
           Default: ''.
 
+[exception] Optional set of configuration to modify tag of the *matched*
+            exception event
+            [remove_tag_prefix] Prefix to remove from the input tag
+            [remove_tag_suffix] Suffix to remove from the input tag
+            [add_tag_prefix]    Prefix to add to the input tag
+            [add_tag_suffix]    Suffix to add to the input tag 
+
 Example configuration:
 
     <match **>
@@ -103,6 +110,12 @@ Example configuration:
       message log
       languages java, python
       multiline_flush_interval 0.1
+
+      # optionally modify tag of the matched exception
+      <exception>
+        remove_tag_prefix app
+        add_tag_suffix crash
+      </exception>
     </match>
 
 == Extending language support

--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -302,7 +302,8 @@ module Fluent
           output_record = @first_record
           output_record[@message_field] = combined_message
         end
-        @emit.call(@first_timestamp, output_record)
+
+        @emit.call(@first_timestamp, output_record, true)
       end
       @messages = []
       @first_record = nil

--- a/lib/fluent/plugin/out_detect_exceptions.rb
+++ b/lib/fluent/plugin/out_detect_exceptions.rb
@@ -123,8 +123,11 @@ module Fluent
           tag = tag[l..-1] if tag.start_with?(s) && tag.length > l
         end
 
-        tag.prepend(@exception.add_tag_prefix, '.') if @exception.add_tag_prefix
-        tag.concat('.', @exception.add_tag_suffix) if @exception.add_tag_suffix
+        if @exception.add_tag_prefix
+          tag.prepend(@exception.add_tag_prefix + '.')
+        end
+
+        tag.concat('.' + @exception.add_tag_suffix) if @exception.add_tag_suffix
       end
 
       router.emit(tag, t, r)

--- a/test/plugin/test_out_detect_exceptions.rb
+++ b/test/plugin/test_out_detect_exceptions.rb
@@ -284,4 +284,26 @@ END
                make_logs(t, 'something else', stream: 'java')
     assert_equal(expected, d.events)
   end
+
+  def test_execption_tag_modification
+    cfg = <<-CFG
+    languages all
+
+    <exception>
+      remove_tag_prefix prefix
+      remove_tag_suffix suffix
+      add_tag_suffix new_suffix
+      add_tag_prefix new_prefix
+    </exception>
+    CFG
+
+    tag = 'prefix.test.suffix'
+
+    d = create_driver(cfg, tag)
+    run_driver(d, ARBITRARY_TEXT, JAVA_EXC, ARBITRARY_TEXT)
+
+    expected = [tag, 'new_prefix.test.new_suffix', tag]
+
+    d.emits.map.with_index { |e, i| assert_equal(e[0], expected[i]) }
+  end
 end


### PR DESCRIPTION
This fixes issue #54 and potentially #67 (records with exception could be tagged differently, for example with tag prefix `exception` which can be later forwarded to the `fluent-plugin-record-modifier` to enrich message).