### PR TITLE
Require "remove_tag_prefix" to be specified in configs.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -42,18 +42,22 @@ will also install and configure the gem.
 
 The plugin supports the following parameters:
 
-[message]  Name of the field in the JSON record that contains the
-           single-line log messages that shall be scanned for exceptions.
-           If this is set to '', the plugin will try 'message' and 'log',
-           in that order.
-           This parameter is only applicable to structured (JSON) log streams.
-           Default: ''.
+=== Required
 
 [remove_tag_prefix]  The prefix to remove from the input tag when outputting
                      a record. A prefix has to be a complete tag part.
                      Example: If remove_tag_prefix is set to 'foo', the input
                      tag foo.bar.baz is transformed to bar.baz and the input tag
                      'foofoo.bar' is not modified. Default: empty string.
+
+=== Optional
+
+[message]  Name of the field in the JSON record that contains the
+           single-line log messages that shall be scanned for exceptions.
+           If this is set to '', the plugin will try 'message' and 'log',
+           in that order.
+           This parameter is only applicable to structured (JSON) log streams.
+           Default: ''.
 
 [languages]  A list of language for which exception stack traces shall be
              detected. The values in the list can be separated by commas or

--- a/lib/fluent/plugin/out_detect_exceptions.rb
+++ b/lib/fluent/plugin/out_detect_exceptions.rb
@@ -42,6 +42,10 @@ module Fluent
     def configure(conf)
       super
 
+      if @remove_tag_prefix.empty?
+        abort("'remove_tag_prefix' is a required config option.")
+      end
+
       if multiline_flush_interval
         @check_flush_interval = [multiline_flush_interval * 0.1, 1].max
       end

--- a/test/plugin/test_out_detect_exceptions.rb
+++ b/test/plugin/test_out_detect_exceptions.rb
@@ -28,6 +28,8 @@ END
 
   DEFAULT_TAG = 'prefix.test.tag'.freeze
 
+  DEFAULT_STRIPPED_TAG = 'test.tag'.freeze
+
   ARBITRARY_TEXT = 'This line is not an exception.'.freeze
 
   JAVA_EXC = <<END.freeze
@@ -125,7 +127,7 @@ END
     }
 
     test_cases.each do |language, exception|
-      cfg = "languages #{language}"
+      cfg = "#{CONFIG}\nlanguages #{language}"
       d = create_driver(cfg)
       t = Time.now.to_i
 
@@ -156,12 +158,12 @@ END
 
       # Validate that each line received is emitted separately as expected.
       router_mock.should_receive(:emit)
-                 .once.with(DEFAULT_TAG, Integer,
+                 .once.with(DEFAULT_STRIPPED_TAG, Integer,
                             'message' => json_line_with_exception,
                             'count' => 0)
 
       router_mock.should_receive(:emit)
-                 .once.with(DEFAULT_TAG, Integer,
+                 .once.with(DEFAULT_STRIPPED_TAG, Integer,
                             'message' => json_line_without_exception,
                             'count' => 1)
 
@@ -174,7 +176,7 @@ END
   end
 
   def test_single_language_config
-    cfg = 'languages java'
+    cfg = "#{CONFIG}\nlanguages java"
     d = create_driver(cfg)
     t = Time.now.to_i
     d.run do
@@ -185,7 +187,7 @@ END
   end
 
   def test_multi_language_config
-    cfg = 'languages python, java'
+    cfg = "#{CONFIG}\nlanguages python, java"
     d = create_driver(cfg)
     t = Time.now.to_i
     d.run do
@@ -196,7 +198,7 @@ END
   end
 
   def test_split_exception_after_timeout
-    cfg = 'multiline_flush_interval 1'
+    cfg = "#{CONFIG}\nmultiline_flush_interval 1"
     d = create_driver(cfg)
     t1 = 0
     t2 = 0
@@ -227,6 +229,11 @@ END
     assert_equal(make_logs(t1, JAVA_EXC + "  at x\n  at y\n"), d.events)
   end
 
+  def test_remove_tag_prefix_is_required
+    cfg = ''
+    assert_raises(SystemExit) { create_driver(cfg) }
+  end
+
   def get_out_tags(remove_tag_prefix, original_tag)
     cfg = "remove_tag_prefix #{remove_tag_prefix}"
     d = create_driver(cfg, original_tag)
@@ -244,7 +251,7 @@ END
   end
 
   def test_flush_after_max_lines
-    cfg = 'max_lines 2'
+    cfg = "#{CONFIG}\nmax_lines 2"
     d = create_driver(cfg)
     t = Time.now.to_i
     d.run do
@@ -263,7 +270,7 @@ END
   end
 
   def test_separate_streams
-    cfg = 'stream stream'
+    cfg = "#{CONFIG}\nstream stream"
     d = create_driver(cfg)
     t = Time.now.to_i
     d.run do


### PR DESCRIPTION
Without this option specified, the output of the plugin will be fed back to
itself, causing infinite recursion and errors that can be hard to understand.

This was initially reported in https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions/issues/9 and this solution was initially
suggested by thomasschickinger.