### PR TITLE
Add detection of java.lang exceptions without colon

### DIFF
--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -53,7 +53,7 @@ module Fluent
 
     JAVA_RULES = [
       rule([:start_state, :java_start_exception],
-           /(?:Exception|Error|Throwable|V8 errors stack trace)[:\r\n]/,
+           /(?:(Exception|Error|Throwable|V8 errors stack trace)[:\r\n]|java[x]?\..*(Exception|Error))/,
            :java_after_exception),
       rule(:java_after_exception, /^[\t ]*nested exception is:[\t ]*/,
            :java_start_exception),

--- a/test/plugin/test_exception_detector.rb
+++ b/test/plugin/test_exception_detector.rb
@@ -16,6 +16,13 @@ require_relative '../helper'
 require 'fluent/plugin/exception_detector'
 
 class ExceptionDetectorTest < Test::Unit::TestCase
+  JAVA_EXC_LANG = <<END.freeze
+    Exception in thread "main" java.lang.NullPointerException
+           at com.example.myproject.Book.getTitle(Book.java:16)
+           at com.example.myproject.Author.getBookTitles(Author.java:25)
+           at com.example.myproject.Bootstrap.main(Bootstrap.java:14)
+END
+
   JAVA_EXC_PART1 = <<END.freeze
 Jul 09, 2015 3:23:29 PM com.google.devtools.search.cloud.feeder.MakeLog: RuntimeException: Run from this message!
   at com.my.app.Object.do$a1(MakeLog.java:50)
@@ -607,6 +614,7 @@ END
     check_exception(JAVA_EXC, false)
     check_exception(COMPLEX_JAVA_EXC, false)
     check_exception(NESTED_JAVA_EXC, false)
+    check_exception(JAVA_EXC_LANG, false)
   end
 
   def test_js


### PR DESCRIPTION
This PR
* adds detection for java stack traces that do not match the existing rule for first line of java.  

My minimal investigation leads me to believe these are `java.lang` exceptions which do not always include a colon for the first line.  As an example of a null pointer:

```
Exception in thread "main" java.lang.NullPointerException
        at com.example.myproject.Book.getTitle(Book.java:16)
        at com.example.myproject.Author.getBookTitles(Author.java:25)
        at com.example.myproject.Bootstrap.main(Bootstrap.java:14)
 ```
